### PR TITLE
tests: add basic integration test cases

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -27,7 +27,7 @@ pipeline {
         stage('Test') {
           steps {
             container('golang') {
-              sh 'go test -cover -race ./...'
+              sh 'go test -short -cover -race ./...'
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:  ## Remove temporary files
 	rm -rf dist
 
 .PHONY: cover
-cover: test  ## Run tests and open an HTML coverage report
+cover: unit-test  ## Run tests and open an HTML coverage report
 	go tool cover -html=coverage.out
 
 .PHONY: dep
@@ -55,9 +55,18 @@ lint:  ## Lint project source files
 	golint -set_exit_status ./pkg/...
 
 .PHONY: test
-test:  ## Run project tests
+test: unit-test integration-test ## Run all project tests
+
+.PHONY: unit-test
+unit-test:  ## Run project unit tests
 	@ # Note: this requires go1.10+ in order to do multi-package coverage reports
-	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	@echo "--> Running Unit Tests"
+	go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
+
+.PHONY: integration-test
+integration-test:  ## Run project integrationt tests
+	@echo "--> Running Integration Tests"
+	@./scripts/integration.sh
 
 .PHONY: version
 version:  ## Print the version of the plugin

--- a/configs/integration-test.yaml
+++ b/configs/integration-test.yaml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  snmp-emulator:
+    image: vaporio/snmp-emulator:latest
+    container_name: snmp-base-integration-emulator
+    ports:
+    - 1024:1024/udp
+    command:
+      - --data-dir=mibs/ups
+      - --agent-udpv4-endpoint=0.0.0.0:1024
+      - --v3-user=simulator
+      - --v3-auth-key=auctoritas
+      - --v3-auth-proto=SHA
+      - --v3-priv-key=privatus
+      - --v3-priv-proto=AES

--- a/pkg/core/client_test.go
+++ b/pkg/core/client_test.go
@@ -319,3 +319,236 @@ func TestNewClient_BadPrivProtocol(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Equal(t, ErrInvalidPrivProtocol, err)
 }
+
+//
+// Integration tests
+//
+// The integration tests run against an instance of the vaporio/snmp-emulator container
+// configured with the UPS MIB (https://tools.ietf.org/html/rfc1628)
+//
+
+func getEmulatorClientConfig() *SnmpTargetConfiguration {
+	return &SnmpTargetConfiguration{
+		MIB:     "test-mib",
+		Version: "v3",
+		Agent:   "udp://127.0.0.1:1024",
+		Security: &SnmpV3Security{
+			Level:    "authPriv",
+			Context:  "public",
+			Username: "simulator",
+			Authentication: &SnmpV3SecurityAuthentication{
+				Protocol:   "SHA",
+				Passphrase: "auctoritas",
+			},
+			Privacy: &SnmpV3SecurityPrivacy{
+				Protocol:   "AES",
+				Passphrase: "privatus",
+			},
+		},
+	}
+}
+
+func TestClientGetExistingOidIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// OID of the UPS MIB upsIdent manufacturer
+	oid := ".1.3.6.1.2.1.33.1.1.1.0"
+
+	pdu, err := client.GetOid(oid)
+	assert.NoError(t, err)
+
+	assert.Equal(t, oid, pdu.Name)
+	assert.Equal(t, gosnmp.OctetString, pdu.Type)
+	assert.Equal(t, "Eaton Corporation", string(pdu.Value.([]uint8)))
+}
+
+func TestClientGetNonexistentOidIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// Some unknown OID
+	oid := ".1.3.6.1.2.1.33.1.1.100.100"
+
+	pdu, err := client.GetOid(oid)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ".1.3.6.1.2.1.33.1.1.100.100", pdu.Name)
+	assert.Equal(t, gosnmp.NoSuchInstance, pdu.Type)
+	assert.Equal(t, nil, pdu.Value)
+}
+
+func TestClientGetBadOidIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// Some invalid OID
+	oid := "."
+
+	pdu, err := client.GetOid(oid)
+	assert.EqualError(t, err, `marshal: unable to parse OID: strconv.Atoi: parsing "": invalid syntax`)
+	assert.Nil(t, pdu)
+}
+
+func TestClientConnectToBadAgentIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	cfg := getEmulatorClientConfig()
+	cfg.Agent = "udp://1.2.3.4:9999"
+	cfg.Timeout = 10 * time.Millisecond
+
+	client, err := NewClient(cfg)
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// OID of the UPS MIB upsIdent manufacturer
+	oid := ".1.3.6.1.2.1.33.1.1.1.0"
+
+	pdu, err := client.GetOid(oid)
+	assert.EqualError(t, err, "Request timeout (after 3 retries)")
+	assert.Nil(t, pdu)
+}
+
+func TestClientGetSupportedDevicesIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// The GetSupportedDevices call requires the client to be connected first,
+	// so establish the connection.
+	err = client.Connect()
+	assert.NoError(t, err)
+
+	// Root OID for the UPS MIB, used by the emulator.
+	devices, err := client.GetSupportedDevices("1.3.6.1.2.1.33")
+	assert.NoError(t, err)
+	assert.Len(t, devices, 60)
+
+	expectedOIDs := []string{
+		"1.3.6.1.2.1.33.1.1.1.0",
+		"1.3.6.1.2.1.33.1.1.2.0",
+		"1.3.6.1.2.1.33.1.1.3.0",
+		"1.3.6.1.2.1.33.1.1.4.0",
+		"1.3.6.1.2.1.33.1.1.5.0",
+		"1.3.6.1.2.1.33.1.1.6.0",
+		"1.3.6.1.2.1.33.1.2.2.0",
+		"1.3.6.1.2.1.33.1.2.3.0",
+		"1.3.6.1.2.1.33.1.2.4.0",
+		"1.3.6.1.2.1.33.1.2.5.0",
+		"1.3.6.1.2.1.33.1.2.6.0",
+		"1.3.6.1.2.1.33.1.2.7.0",
+		"1.3.6.1.2.1.33.1.3.2.0",
+		"1.3.6.1.2.1.33.1.3.3.1.2.1",
+		"1.3.6.1.2.1.33.1.3.3.1.2.2",
+		"1.3.6.1.2.1.33.1.3.3.1.2.3",
+		"1.3.6.1.2.1.33.1.3.3.1.3.1",
+		"1.3.6.1.2.1.33.1.3.3.1.3.2",
+		"1.3.6.1.2.1.33.1.3.3.1.3.3",
+		"1.3.6.1.2.1.33.1.3.3.1.4.1",
+		"1.3.6.1.2.1.33.1.3.3.1.4.2",
+		"1.3.6.1.2.1.33.1.3.3.1.4.3",
+		"1.3.6.1.2.1.33.1.3.3.1.5.1",
+		"1.3.6.1.2.1.33.1.3.3.1.5.2",
+		"1.3.6.1.2.1.33.1.3.3.1.5.3",
+		"1.3.6.1.2.1.33.1.4.1.0",
+		"1.3.6.1.2.1.33.1.4.2.0",
+		"1.3.6.1.2.1.33.1.4.3.0",
+		"1.3.6.1.2.1.33.1.4.4.1.2.1",
+		"1.3.6.1.2.1.33.1.4.4.1.2.2",
+		"1.3.6.1.2.1.33.1.4.4.1.2.3",
+		"1.3.6.1.2.1.33.1.4.4.1.3.1",
+		"1.3.6.1.2.1.33.1.4.4.1.3.2",
+		"1.3.6.1.2.1.33.1.4.4.1.3.3",
+		"1.3.6.1.2.1.33.1.4.4.1.4.1",
+		"1.3.6.1.2.1.33.1.4.4.1.4.2",
+		"1.3.6.1.2.1.33.1.4.4.1.4.3",
+		"1.3.6.1.2.1.33.1.4.4.1.5.1",
+		"1.3.6.1.2.1.33.1.4.4.1.5.2",
+		"1.3.6.1.2.1.33.1.4.4.1.5.3",
+		"1.3.6.1.2.1.33.1.5.1.0",
+		"1.3.6.1.2.1.33.1.5.2.0",
+		"1.3.6.1.2.1.33.1.5.3.1.2.1",
+		"1.3.6.1.2.1.33.1.5.3.1.2.2",
+		"1.3.6.1.2.1.33.1.5.3.1.2.3",
+		"1.3.6.1.2.1.33.1.6.1.0",
+		"1.3.6.1.2.1.33.1.6.2.1.2.1",
+		"1.3.6.1.2.1.33.1.6.2.1.2.2",
+		"1.3.6.1.2.1.33.1.6.2.1.3.1",
+		"1.3.6.1.2.1.33.1.6.2.1.3.2",
+		"1.3.6.1.2.1.33.1.7.3.0",
+		"1.3.6.1.2.1.33.1.7.4.0",
+		"1.3.6.1.2.1.33.1.7.5.0",
+		"1.3.6.1.2.1.33.1.7.6.0",
+		"1.3.6.1.2.1.33.1.8.1.0",
+		"1.3.6.1.2.1.33.1.8.5.0",
+		"1.3.6.1.2.1.33.1.9.1.0",
+		"1.3.6.1.2.1.33.1.9.2.0",
+		"1.3.6.1.2.1.33.1.9.3.0",
+		"1.3.6.1.2.1.33.1.9.4.0",
+	}
+
+	for i, oid := range expectedOIDs {
+		assert.Contains(t, devices, oid, "oid:%s index:%d", oid, i)
+		assert.Equal(t, struct{}{}, devices[oid])
+	}
+}
+
+func TestClientGetSupportedDevicesNotConnectedIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// The GetSupportedDevices call requires the client to be connected first,
+	// but this test checks the case where it is not connected, so do not
+	// connect prior to calling GetSupportedDevices.
+
+	// Root OID for the UPS MIB, used by the emulator.
+	devices, err := client.GetSupportedDevices("1.3.6.1.2.1.33")
+	assert.EqualError(t, err, "&GoSNMP.Conn is missing. Provide a connection or use Connect()")
+	assert.Nil(t, devices)
+}
+
+func TestClientGetSupportedDevicesInvalidRootOIDIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	client, err := NewClient(getEmulatorClientConfig())
+	defer client.Close()
+	assert.NoError(t, err)
+
+	// The GetSupportedDevices call requires the client to be connected first,
+	// so establish the connection.
+	err = client.Connect()
+	assert.NoError(t, err)
+
+	// Invalid root OID.
+	devices, err := client.GetSupportedDevices("foo")
+	assert.EqualError(t, err, `marshal: unable to parse OID: strconv.Atoi: parsing "foo": invalid syntax`)
+	assert.Nil(t, devices)
+}

--- a/pkg/handlers/read.go
+++ b/pkg/handlers/read.go
@@ -83,6 +83,6 @@ func readHandlerFunc(device *sdk.Device) ([]*output.Reading, error) {
 	}
 
 	return []*output.Reading{
-		o.MakeReading(value),
+		o.MakeReading(value).WithContext(device.Context),
 	}, nil
 }

--- a/pkg/handlers/read_test.go
+++ b/pkg/handlers/read_test.go
@@ -65,3 +65,117 @@ func TestReadHandlerFunc_FailedClientInit(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, readings)
 }
+
+//
+// Integration tests
+//
+// The integration tests run against an instance of the vaporio/snmp-emulator container
+// configured with the UPS MIB (https://tools.ietf.org/html/rfc1628)
+//
+
+func getEmulatorClientConfig() *core.SnmpTargetConfiguration {
+	return &core.SnmpTargetConfiguration{
+		MIB:     "test-mib",
+		Version: "v3",
+		Agent:   "udp://127.0.0.1:1024",
+		Security: &core.SnmpV3Security{
+			Level:    "authPriv",
+			Context:  "public",
+			Username: "simulator",
+			Authentication: &core.SnmpV3SecurityAuthentication{
+				Protocol:   "SHA",
+				Passphrase: "auctoritas",
+			},
+			Privacy: &core.SnmpV3SecurityPrivacy{
+				Protocol:   "AES",
+				Passphrase: "privatus",
+			},
+		},
+	}
+}
+
+func getReadTestDevice(oid string) *sdk.Device {
+	cfg := getEmulatorClientConfig()
+	return &sdk.Device{
+		Type:   "test",
+		Info:   "a test device",
+		Output: "status", // some generic output for the test
+		Data: map[string]interface{}{
+			"mib":        "test-mib",
+			"agent":      cfg.Agent,
+			"target_cfg": cfg,
+			"oid":        oid,
+		},
+		Context: map[string]string{
+			"oid":   oid,
+			"other": "foobar",
+		},
+	}
+}
+
+func TestReadHandlerFuncIdentStringIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	// OID of the UPS MIB upsIdent manufacturer
+	oid := ".1.3.6.1.2.1.33.1.1.1.0"
+
+	device := getReadTestDevice(oid)
+
+	readings, err := readHandlerFunc(device)
+	assert.NoError(t, err)
+	assert.Len(t, readings, 1)
+	assert.Equal(t, "status", readings[0].Type) // determined by test device "output" type (status)
+	assert.Equal(t, "Eaton Corporation", readings[0].Value)
+	assert.Equal(t, map[string]string{
+		"oid":   oid,
+		"other": "foobar",
+	}, readings[0].Context)
+}
+
+// FIXME (etd):  This is returning nil. Need to look into why that is. Is it not being parsed
+//   correctly in the handler? Is it missing from the emulator? Something else?
+// UPDATE (etd): Turning on logging, I see: got reading value for OID" name=.1.3.6.1.2.1.33.1.2.1.0 type=NoSuchInstance value="<nil>"
+//   so I think this means 2 things: its not in the emulator, and we may need some sort of handling/logging for NoSuchInstance?
+//func TestReadHandlerFuncBatteryEnumIntegration(t *testing.T) {
+//	if testing.Short() {
+//		t.Skip("skipping integration test: --short flag set")
+//	}
+//
+//	// OID of the UPS MIB upsBattery status
+//	oid := ".1.3.6.1.2.1.33.1.2.1.0"
+//
+//	device := getReadTestDevice(oid)
+//
+//	readings, err := readHandlerFunc(device)
+//	assert.NoError(t, err)
+//	assert.Len(t, readings, 1)
+//	assert.Equal(t, "status", readings[0].Type)  // determined by test device "output" type (status)
+//	assert.Equal(t, "Eaton Corporation", readings[0].Value)
+//	assert.Equal(t, map[string]string{
+//		"oid": oid,
+//		"other": "foobar",
+//	}, readings[0].Context)
+//}
+
+func TestReadHandlerFuncBatteryTemperatureIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test: --short flag set")
+	}
+
+	// OID of the UPS MIB upsBattery temperature
+	oid := ".1.3.6.1.2.1.33.1.2.7.0"
+
+	device := getReadTestDevice(oid)
+
+	readings, err := readHandlerFunc(device)
+	assert.NoError(t, err)
+	assert.Len(t, readings, 1)
+	assert.Equal(t, "status", readings[0].Type) // determined by test device "output" type (status)
+	assert.Equal(t, int(24), readings[0].Value)
+	assert.Equal(t, map[string]string{
+		"oid":   oid,
+		"other": "foobar",
+	}, readings[0].Context)
+}

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# integration.sh
+#
+# Integration test runner script. This should be run from the project root
+# (./scripts/integration.sh) or via Make target (make integration-test).
+#
+# This script starts an emulator container and runs the integration tests.
+# Once the tests complete, it will clean up the container(s).
+#
+
+docker-compose -f configs/integration-test.yaml up -d
+sleep 2
+
+go test -run Integration -coverprofile=coverage.out -covermode=atomic ./...
+rc=$?
+
+if [[ ${rc} -ne 0 ]]; then
+    echo "-------------------------------------------------------------------"
+    echo "Error: Integration tests failed. The emulator container is cleaned"
+    echo "  up by default. If you wish to inspect the logs, disable container"
+    echo "  removal in ./scripts/integration.sh"
+    echo "-------------------------------------------------------------------"
+fi
+
+docker-compose -f configs/integration-test.yaml rm --force --stop
+
+exit ${rc}


### PR DESCRIPTION
This PR:
- adds some basic integration tests to the project, run against the vaporio/snmp-emulator container (following the pattern noted here:  https://stackoverflow.com/a/41407042)
- adds some additional logging  messages
- fixes a few bugs
  - readings were being returned without device context. this isn't really a bug,  as thats how it was first envisioned, but I think including the device context is good, especially if plugins built on top of this base assign some additional context to the devices.
  - if timeout isn't set for the snmp client, it appears to use a timeout of 0s, so it always  times out. adds a  default timeout
  - if retries aren't set, it will not retry.  we want  retries.  adds a default retry count.


This isn't totally complete, but I think its a good enough first chunk to warrant its own PR.  The other two remaining bits  here are:
- fix the test that is disabled. need to track down whether the issue is with data not being in the emulator or whether its an issue with how the plugin is parsing that data, so this will require a little bit of digging first.
- add integration tests to CI. I explicitly don't  want to do this here because I've had issues getting the standalone snmp-emulator working  in CI,  so I need to spend some time circling back to that and seeing if I can figure  out what the issue was. (I also need to update the pipeline to the new style, and that also feels like a different PR)