### PR TITLE
update jenkins to use shared ci config

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 // Include this shared CI repository to load script helpers and libraries.
-library identifier: 'vapor@etd/snmp-emulator', retriever: modernSCM([
+library identifier: 'vapor@1.0.0-RC13', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'https://github.com/vapor-ware/ci-shared.git',
   credentialsId: 'vio-bot-gh',

--- a/.jenkins
+++ b/.jenkins
@@ -1,61 +1,16 @@
 #!/usr/bin/env groovy
 
-pipeline {
+// Include this shared CI repository to load script helpers and libraries.
+library identifier: 'vapor@etd/snmp-emulator', retriever: modernSCM([
+  $class: 'GitSCMSource',
+  remote: 'https://github.com/vapor-ware/ci-shared.git',
+  credentialsId: 'vio-bot-gh',
+])
 
-  agent {
-    label 'golang-alpha'
-  }
 
-  stages {
-    stage('Checkout') {
-      steps {
-        checkout scm
-      }
-    }
-
-    stage('Checks') {
-      parallel {
-
-        stage('Lint') {
-          steps {
-            container('golang') {
-              sh 'golint -set_exit_status ./...'
-            }
-          }
-        }
-
-        stage('Test') {
-          steps {
-            container('golang') {
-              sh 'go test -short -cover -race ./...'
-            }
-          }
-        }
-
-        stage('Snapshot Build') {
-          steps {
-            container('golang') {
-              sh 'goreleaser release --debug --snapshot --skip-publish --rm-dist'
-            }
-          }
-        }
-      }
-    }
-
-    stage('Tagged Release') {
-      when {
-        buildingTag()
-      }
-      environment {
-        GITHUB_TOKEN = credentials('vio-bot-gh-token')
-      }
-      steps {
-        container('golang') {
-          withDockerRegistry(registry: [credentialsId: 'vio-docker-hub']) {
-            sh 'goreleaser release --debug --rm-dist'
-          }
-        }
-      }
-    }
-  }
-}
+golangPipeline([
+  'image': 'vaporio/snmp-plugin',
+  'emulators': [
+    'snmp',
+  ],
+])

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ github-tag:  ## Create and push a tag with the current version
 lint:  ## Lint project source files
 	golint -set_exit_status ./pkg/...
 
-.PHONY: test
-test: unit-test integration-test ## Run all project tests
+.PHONY: test-all
+test-all: unit-test integration-test  ## Run all project tests
 
 .PHONY: unit-test
 unit-test:  ## Run project unit tests
@@ -77,3 +77,13 @@ help:  ## Print usage information
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 .DEFAULT_GOAL := help
+
+
+# Targets for Jenkins CI
+
+.PHONY: test
+test: unit-test
+
+.PHONY: ci-integration-test
+ci-integration-test:
+	go test -run Integration -coverprofile=coverage.out -covermode=atomic ./...

--- a/configs/integration-test.yaml
+++ b/configs/integration-test.yaml
@@ -6,10 +6,4 @@ services:
     ports:
     - 1024:1024/udp
     command:
-      - --data-dir=mibs/ups
-      - --agent-udpv4-endpoint=0.0.0.0:1024
-      - --v3-user=simulator
-      - --v3-auth-key=auctoritas
-      - --v3-auth-proto=SHA
-      - --v3-priv-key=privatus
-      - --v3-priv-proto=AES
+      - 'mibs/ups'


### PR DESCRIPTION
This PR:
- updates jenkins to use the shared pipeline
- sets up integration tests in CI using  the snmp emulator (https://github.com/vapor-ware/snmp-emulator)
     - the snmp-emulator being used here is based off the image defined in its own repo (above) as opposed to the  one defined in the snmp-plugin repo mainly just so we can have a reusable snmp emulator not tied to a particular plugin repo, since this emulator can be used to test the existing snmp-plugin, and the experimental snmp-base + snmp-ups-plugin

fixes #7 